### PR TITLE
fix: suppress Dokka 'main' source set to prevent overlapping source root validation error

### DIFF
--- a/buildSrc/src/main/java/co/anitrend/support/markdown/buildSrc/plugin/components/AndroidPlugins.kt
+++ b/buildSrc/src/main/java/co/anitrend/support/markdown/buildSrc/plugin/components/AndroidPlugins.kt
@@ -3,6 +3,7 @@ package co.anitrend.support.markdown.buildSrc.plugin.components
 import co.anitrend.support.markdown.buildSrc.common.isLibraryModule
 import co.anitrend.support.markdown.buildSrc.common.isSampleModule
 import org.gradle.api.Project
+import org.jetbrains.dokka.gradle.DokkaExtension
 
 private fun Project.applyModulePlugin() {
     plugins.apply("com.diffplug.spotless")
@@ -10,9 +11,24 @@ private fun Project.applyModulePlugin() {
         plugins.apply("com.android.library")
         plugins.apply("org.jetbrains.dokka")
         plugins.apply("maven-publish")
+        configureDokka()
     }
     else
         plugins.apply("com.android.application")
+}
+
+private fun Project.configureDokka() {
+    plugins.withId("org.jetbrains.dokka") {
+        afterEvaluate {
+            extensions.configure(DokkaExtension::class.java) {
+                dokkaSourceSets.all {
+                    if (name == "main") {
+                        suppress.set(true)
+                    }
+                }
+            }
+        }
+    }
 }
 
 internal fun Project.configurePlugins() {


### PR DESCRIPTION
## Summary

Fixes the failing Dokka generation CI at https://github.com/AniTrend/support-markdown/actions/runs/26652957865/job/78555769646

## Root Cause

Dokka V2 creates both `main` (internally remapped to `androidJvm` by the worker) and `release` source sets for Android library modules, both pointing to `src/main/kotlin`. The pre-generation validity check rejects overlapping source roots.

## Fix

Suppress the `main` Dokka source set via `afterEvaluate` so only the `release` variant source set remains active, eliminating the overlap.

## Verification

- `clean test` ✓
- `clean dokkaGenerateHtml` ✓ (2.7M HTML output generated)
- `:buildSrc:compileKotlin` ✓